### PR TITLE
feat: search_messages

### DIFF
--- a/pocs/concur/outlook_client.py
+++ b/pocs/concur/outlook_client.py
@@ -18,10 +18,13 @@ class OutlookClient:
         self.base_url = "https://graph.microsoft.com/v1.0"
         self.session = requests.Session()
 
-    def _make_request(self, method: str, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+    def _make_request(self, method: str, endpoint: str, params: Optional[Dict] = None, headers: Optional[Dict] = None) -> Dict[str, Any]:
         """Make authenticated request to Outlook API."""
         token = self.authenticator.get_access_token()
-        self.session.headers.update({"Authorization": f"Bearer {token}"})
+        request_headers = {"Authorization": f"Bearer {token}"}
+        if headers:
+            request_headers.update(headers)
+        self.session.headers.update(request_headers)
 
         url = f"{self.base_url}{endpoint}"
         response = self.session.request(method, url, params=params, timeout=30)
@@ -30,7 +33,8 @@ class OutlookClient:
         if response.status_code in (401, 403):
             logger.debug("Token expired, retrying with fresh token")
             token = self.authenticator.get_access_token()
-            self.session.headers.update({"Authorization": f"Bearer {token}"})
+            request_headers["Authorization"] = f"Bearer {token}"
+            self.session.headers.update(request_headers)
             response = self.session.request(method, url, params=params, timeout=30)
 
         response.raise_for_status()
@@ -88,3 +92,39 @@ class OutlookClient:
         attachments = response_data.get("value", [])
         logger.debug(f"Found {len(attachments)} attachments")
         return attachments
+
+    def search_messages(self, search_term: str, limit=50, select_fields=None) -> List[Dict[str, Any]]:
+        """
+        Search for messages containing a specific term.
+
+        Args:
+            search_term: Term to search for in messages
+            limit: Number of messages to retrieve
+            select_fields: List of fields to select
+
+        Returns:
+            List of message dictionaries matching the search term
+        """
+        endpoint = "/me/messages"
+
+        params = {
+            "$search": f'"{search_term}"',
+            "$top": limit
+        }
+
+        if select_fields:
+            params["$select"] = ",".join(select_fields)
+
+        logger.info(f"Searching for messages containing: {search_term}")
+
+        # Search requires ConsistencyLevel header
+        headers = {"ConsistencyLevel": "eventual"}
+        response_data = self._make_request("GET", endpoint, params, headers)
+
+        messages = response_data.get("value", [])
+
+        # Client-side sort by receivedDateTime desc (search doesn't support $orderby)
+        messages.sort(key=lambda m: m.get("receivedDateTime", ""), reverse=True)
+
+        logger.info(f"Found {len(messages)} messages matching '{search_term}'")
+        return messages

--- a/pocs/concur/outlook_main.py
+++ b/pocs/concur/outlook_main.py
@@ -45,6 +45,7 @@ def load_config():
     config["scopes"] = ["Mail.Read"]
     config["message_limit"] = int(os.getenv("MESSAGE_LIMIT", "10"))
     config["log_level"] = os.getenv("LOG_LEVEL", "INFO")
+    config["search_term"] = os.getenv("SEARCH_TERM", "")  # Optional search term
 
     return config
 
@@ -90,10 +91,19 @@ def main():
             "hasAttachments", "bodyPreview"
         ]
 
-        messages = client.get_messages(
-            limit=config["message_limit"],
-            select_fields=select_fields
-        )
+        # Use search if search_term is provided, otherwise get inbox messages
+        if config["search_term"]:
+            logger.info(f"Searching for: '{config['search_term']}'")
+            messages = client.search_messages(
+                search_term=config["search_term"],
+                limit=config["message_limit"],
+                select_fields=select_fields
+            )
+        else:
+            messages = client.get_messages(
+                limit=config["message_limit"],
+                select_fields=select_fields
+            )
 
         if not messages:
             logger.info("No messages found")


### PR DESCRIPTION
This pull request adds the ability to search for Outlook messages by a specific term, improves header handling for authenticated requests, and introduces a configuration option for specifying a search term. The main logic now conditionally uses the search feature if a search term is provided, otherwise it retrieves inbox messages as before.

**New search functionality:**

* Added a new `search_messages` method to the `OutlookClient` class, allowing searching for messages containing a specific term, with support for result limiting and field selection. The method also sorts results by `receivedDateTime` in descending order.

**Configuration and main flow updates:**

* Added a `search_term` option to the configuration, loaded from the `SEARCH_TERM` environment variable.
* Updated the main logic in `outlook_main.py` to use the new search functionality when a search term is specified, otherwise defaulting to inbox retrieval.

**Request handling improvements:**

* Enhanced the `_make_request` method in `OutlookClient` to accept custom headers, enabling use of the `ConsistencyLevel` header required for search queries.
* Improved token refresh logic to update the request headers more robustly when retrying after authentication errors.